### PR TITLE
enable configuration of interactive input for provider GoogleMaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Currently, only Google Maps is supported for interactive maps.
 * `OpenStreetMaps`
 * `MapQuest`
 
+### input_type
+
+Specify the type of input you want to use.
+Provider GoogleMaps supports interactive input, but does not allow searching.
+If you change this value to any other option, a textbox will be used for GoogleMaps instead. This is useful when you prefer to use copy and paste.
+
+* `provider`
+* anything else ...
+
 ### api_key
 
 Depending on the provider you are using, you might need to enter the API key.

--- a/interactiveform.class.inc.php
+++ b/interactiveform.class.inc.php
@@ -41,32 +41,35 @@ class GeolocationInteractiveForm implements iApplicationUIExtension
 		$iDefaultLng = utils::GetConfig()->GetModuleSetting('sv-geolocation', 'default_longitude');
 		$iZoom = utils::GetConfig()->GetModuleSetting('sv-geolocation', 'default_zoom');
 		$bDisplay = utils::GetConfig()->GetModuleSetting('sv-geolocation', 'display_coordinates');
+		$sInputType = utils::GetConfig()->GetModuleSetting('sv-geolocation', 'input_type');
 		list($sLang, $sRegion) = explode(' ', UserRights::GetUserLanguage(), 2);
-		
-		switch (utils::GetConfig()->GetModuleSetting('sv-geolocation', 'provider'))
-		{
-			case 'GoogleMaps':
-				switch (UserRights::GetUserLanguage())
-				{
-					case 'PT BR':
-					case 'ZH CN':
-						$sLang = strtolower($sLang).'-'.$sRegion;
-						break;
-					default:
-						$sLang = strtolower($sLang);
-						break;
-				}
 
-				$oPage->add_linked_script(sprintf('https://maps.googleapis.com/maps/api/js?key=%s&callback=$.noop&language=%s', $sApiKey, $sLang));
-				$oPage->add_linked_script(utils::GetAbsoluteUrlModulesRoot().'sv-geolocation/js/google-maps-utils.js');
-				
-				$oAttOptions = array('code' => $oAttDef->GetCode(), 'width' => $oAttDef->GetWidth(), 'height' => $oAttDef->GetHeight(), 'display' => $bDisplay);
-				$oMapOptions = array('center' => new ormGeolocation($iDefaultLat, $iDefaultLng), 'zoom' => $iZoom);
-				
-				$oPage->add_ready_script(sprintf('make_interactive_map(%s, %s);', json_encode($oAttOptions), json_encode($oMapOptions)));
-				break;
-			default:
-				break;
+		if ($sInputType == 'provider') {
+			switch (utils::GetConfig()->GetModuleSetting('sv-geolocation', 'provider'))
+			{
+				case 'GoogleMaps':
+					switch (UserRights::GetUserLanguage())
+					{
+						case 'PT BR':
+						case 'ZH CN':
+							$sLang = strtolower($sLang).'-'.$sRegion;
+							break;
+						default:
+							$sLang = strtolower($sLang);
+							break;
+					}
+
+					$oPage->add_linked_script(sprintf('https://maps.googleapis.com/maps/api/js?key=%s&callback=$.noop&language=%s', $sApiKey, $sLang));
+					$oPage->add_linked_script(utils::GetAbsoluteUrlModulesRoot().'sv-geolocation/js/google-maps-utils.js');
+
+					$oAttOptions = array('code' => $oAttDef->GetCode(), 'width' => $oAttDef->GetWidth(), 'height' => $oAttDef->GetHeight(), 'display' => $bDisplay);
+					$oMapOptions = array('center' => new ormGeolocation($iDefaultLat, $iDefaultLng), 'zoom' => $iZoom);
+
+					$oPage->add_ready_script(sprintf('make_interactive_map(%s, %s);', json_encode($oAttOptions), json_encode($oMapOptions)));
+					break;
+				default:
+					break;
+			}
 		}
 	}
 	

--- a/module.sv-geolocation.php
+++ b/module.sv-geolocation.php
@@ -46,6 +46,7 @@ SetupWebPage::AddModule(
 		//
 		'settings' => array(
 			'provider' => 'GoogleMaps',
+			'input_type' => 'provider',
 			'api_key' => null,
 			'default_latitude' => 45.157389,
 			'default_longitude' => 5.748830,


### PR DESCRIPTION
When Google Maps is selected as the provider, the input uses an interactive search method. 
However, if you want to copy and paste geo-coordinates, the interactive input may not be convenient.